### PR TITLE
fix strcmp returning wrong values

### DIFF
--- a/amx/amxstring.c
+++ b/amx/amxstring.c
@@ -324,24 +324,24 @@ static int compare(cell *cstr1,cell *cstr2,int ignorecase,int length,int offs1)
  */
 static cell AMX_NATIVE_CALL n_strcmp(AMX *amx,const cell *params)
 {
-  cell *cstr1, *cstr2;
-  int len1, len2;
+  cell *cstr1,*cstr2;
+  int len1,len2;
 
   (void)(amx);
-  cstr1 = amx_Address(amx, params[1]);
-  cstr2 = amx_Address(amx, params[2]);
+  cstr1=amx_Address(amx,params[1]);
+  cstr2=amx_Address(amx,params[2]);
   amx_StrLen(cstr1,&len1);
   amx_StrLen(cstr2,&len2);
 
   if (len1>params[4])
-	  len1 = params[4];
+	  len1=params[4];
   if (len2>params[4])
-	  len2 = params[4];
+	  len2=params[4];
   if (len1>len2)
 	  return 1;
   if (len1<len2)
 	  return -1;
-  return (cell)compare(cstr1, cstr2, params[3], len1, 0);
+  return (cell)compare(cstr1,cstr2,params[3],len1,0);
 }
 
 /* strfind(const string[], const sub[], bool:ignorecase=false, offset=0)

--- a/amx/amxstring.c
+++ b/amx/amxstring.c
@@ -324,29 +324,24 @@ static int compare(cell *cstr1,cell *cstr2,int ignorecase,int length,int offs1)
  */
 static cell AMX_NATIVE_CALL n_strcmp(AMX *amx,const cell *params)
 {
-  cell *cstr1,*cstr2;
-  int len1,len2,len;
-  cell result;
+  cell *cstr1, *cstr2;
+  int len1, len2;
 
   (void)(amx);
-  cstr1=amx_Address(amx,params[1]);
-  cstr2=amx_Address(amx,params[2]);
-
-  /* get the maximum length to compare */
+  cstr1 = amx_Address(amx, params[1]);
+  cstr2 = amx_Address(amx, params[2]);
   amx_StrLen(cstr1,&len1);
   amx_StrLen(cstr2,&len2);
-  len=len1;
-  if (len>len2)
-    len=len2;
-  if (len>params[4])
-    len=params[4];
-  if (len==0)
-    return (params[4]==0) ? 0 : len1-len2;
 
-  result=compare(cstr1,cstr2,params[3],len,0);
-  if (result==0 && len!=params[4])
-    result=len1-len2;
-  return result;
+  if (len1>params[4])
+	  len1 = params[4];
+  if (len2>params[4])
+	  len2 = params[4];
+  if (len1>len2)
+	  return 1;
+  if (len1<len2)
+	  return -1;
+  return (cell)compare(cstr1, cstr2, params[3], len1, 0);
 }
 
 /* strfind(const string[], const sub[], bool:ignorecase=false, offset=0)


### PR DESCRIPTION
Fixes #13.
Test code:
```Pawn
#include <console>
#include <string>
main()
{
	static const test_strings[4]{12} = ["", "123", "abc", "abcde"];
	for (new i = 0; i < sizeof(test_strings); ++i)
		for (new j = 0; j < sizeof(test_strings); ++j)
			printf("strcmp(\"%s\" \"%s\"): %d\n", test_strings[i], test_strings[j],
				strcmp(test_strings[i], test_strings[j]));
}
```
Output:
```
strcmp("" ""): 0
strcmp("" "123"): -1
strcmp("" "abc"): -1
strcmp("" "abcde"): -1
strcmp("123" ""): 1
strcmp("123" "123"): 0
strcmp("123" "abc"): -1
strcmp("123" "abcde"): -1
strcmp("abc" ""): 1
strcmp("abc" "123"): 1
strcmp("abc" "abc"): 0
strcmp("abc" "abcde"): -1
strcmp("abcde" ""): 1
strcmp("abcde" "123"): 1
strcmp("abcde" "abc"): 1
strcmp("abcde" "abcde"): 0
```