### PR TITLE
Fix for Linux compilation

### DIFF
--- a/amx/amxargs.c
+++ b/amx/amxargs.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <unistd.h>
 #include "osdefs.h"
 #if defined __WIN32__ || defined __MSDOS__
   #include <malloc.h>

--- a/amx/amxfile.c
+++ b/amx/amxfile.c
@@ -50,6 +50,7 @@
 #endif
 #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined MACOS || defined __APPLE__
   #include <dirent.h>
+  #include <unistd.h>
 #else
   #include <io.h>
 #endif
@@ -90,7 +91,7 @@
   #define _tgetenv      getenv
   #define _tremove      remove
   #define _trename      rename
-  #if defined __APPLE__
+  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined MACOS || defined __APPLE__
     #define _tmkdir     mkdir
     #define _trmdir     rmdir
     #define _tstat      stat
@@ -505,14 +506,14 @@ static cell AMX_NATIVE_CALL n_fopen(AMX *amx, const cell *params)
     if (f==NULL && altattrib!=NULL)
       f=_tfopen(fullname,altattrib);
   } /* if */
-  return (cell)f;
+  return *(cell*)f;
 }
 
 /* fclose(File: handle) */
 static cell AMX_NATIVE_CALL n_fclose(AMX *amx, const cell *params)
 {
   (void)amx;
-  return fclose((FILE*)params[1]) == 0;
+  return fclose((FILE*)&params[1]) == 0;
 }
 
 /* fwrite(File: handle, const string[]) */
@@ -533,11 +534,11 @@ static cell AMX_NATIVE_CALL n_fwrite(AMX *amx, const cell *params)
     /* the string is packed, write it as an ASCII/ANSI string */
     if ((str=(char*)alloca(len + 1))!=NULL) {
       amx_GetString(str,cptr,0,len);
-      r=fputs(str,(FILE*)params[1]);
+      r=fputs(str,(FILE*)&params[1]);
     } /* if */
   } else {
     /* the string is unpacked, write it as UTF-8 */
-    r=fputs_cell((FILE*)params[1],cptr,1);
+    r=fputs_cell((FILE*)&params[1],cptr,1);
   } /* if */
   return (cell)r;
 }
@@ -565,12 +566,12 @@ static cell AMX_NATIVE_CALL n_fread(AMX *amx, const cell *params)
 
   if (params[4]) {
     /* store as packed string, read an ASCII/ANSI string */
-    chars=fgets_char((FILE*)params[1],str,max);
+    chars=fgets_char((FILE*)&params[1],str,max);
     assert((int)chars<max);
     amx_SetString(cptr,str,1,0,max);
   } else {
     /* store and unpacked string, interpret UTF-8 */
-    chars=fgets_cell((FILE*)params[1],cptr,max,1);
+    chars=fgets_cell((FILE*)&params[1],cptr,max,1);
   } /* if */
 
   assert((int)chars<max);
@@ -587,9 +588,9 @@ static cell AMX_NATIVE_CALL n_fputchar(AMX *amx, const cell *params)
     cell str[2];
     str[0]=params[2];
     str[1]=0;
-    result=fputs_cell((FILE*)params[1],str,1);
+    result=fputs_cell((FILE*)&params[1],str,1);
   } else {
-    fputc((int)params[2],(FILE*)params[1]);
+    fputc((int)params[2],(FILE*)&params[1]);
 	result=1;
   } /* if */
   assert(result==0 || result==1);
@@ -604,9 +605,9 @@ static cell AMX_NATIVE_CALL n_fgetchar(AMX *amx, const cell *params)
 
   (void)amx;
   if (params[2]) {
-    result=fgets_cell((FILE*)params[1],str,2,1);
+    result=fgets_cell((FILE*)&params[1],str,2,1);
   } else {
-    str[0]=fgetc((FILE*)params[1]);
+    str[0]=fgetc((FILE*)&params[1]);
     result= (str[0]!=EOF);
   } /* if */
   assert(result==0 || result==1);
@@ -639,7 +640,7 @@ static cell AMX_NATIVE_CALL n_fblockwrite(AMX *amx, const cell *params)
     ucell v;
     for (count=0; count<max; count++) {
       v=(ucell)*cptr++;
-      if (fwrite(aligncell(&v),sizeof(cell),1,(FILE*)params[1])!=1)
+      if (fwrite(aligncell(&v),sizeof(cell),1,(FILE*)&params[1])!=1)
         break;          /* write error */
     } /* for */
   } /* if */
@@ -658,7 +659,7 @@ static cell AMX_NATIVE_CALL n_fblockread(AMX *amx, const cell *params)
     cell max=params[3];
     ucell v;
     for (count=0; count<max; count++) {
-      if (fread(&v,sizeof(cell),1,(FILE*)params[1])!=1)
+      if (fread(&v,sizeof(cell),1,(FILE*)&params[1])!=1)
         break;          /* write error */
       *cptr++=(cell)*aligncell(&v);
     } /* for */
@@ -671,7 +672,7 @@ static cell AMX_NATIVE_CALL n_ftemp(AMX *amx, const cell *params)
 {
   (void)amx;
   (void)params;
-  return (cell)tmpfile();
+  return *(cell*)tmpfile();
 }
 
 /* fseek(File: handle, position, seek_whence: whence=seek_start) */
@@ -694,7 +695,7 @@ static cell AMX_NATIVE_CALL n_fseek(AMX *amx, const cell *params)
   default:
     return 0;
   } /* switch */
-  return lseek(fileno((FILE*)params[1]),params[2],whence);
+  return lseek(fileno((FILE*)&params[1]),params[2],whence);
 }
 
 /* bool: fremove(const name[]) */
@@ -765,7 +766,7 @@ static cell AMX_NATIVE_CALL n_frename(AMX *amx, const cell *params)
 static cell AMX_NATIVE_CALL n_flength(AMX *amx, const cell *params)
 {
   long l,c;
-  int fn=fileno((FILE*)params[1]);
+  int fn=fileno((FILE*)&params[1]);
   c=lseek(fn,0,SEEK_CUR); /* save the current position */
   l=lseek(fn,0,SEEK_END); /* return the file position at its end */
   lseek(fn,c,SEEK_SET);   /* restore the file pointer */

--- a/amx/amxprocess.c
+++ b/amx/amxprocess.c
@@ -532,7 +532,7 @@ static cell AMX_NATIVE_CALL n_libcall(AMX *amx, const cell *params)
         dcArgPointer(dcVM,ps[idx].v.ptr);
       } /* if */
     } /* for */
-    result=(cell)dcCallPointer(dcVM,(void*)LibFunc);
+    result=*(cell*)dcCallPointer(dcVM,(void*)LibFunc);
   #else /* HAVE_DYNCALL_H */
     /* push the parameters to the stack (left-to-right in 16-bit; right-to-left
      * in 32-bit)

--- a/amx/amxtime.c
+++ b/amx/amxtime.c
@@ -22,6 +22,8 @@
 #if defined __WIN32__ || defined _WIN32 || defined _Windows
   #include <windows.h>
   #include <mmsystem.h>
+#elif defined __linux || defined __linux__ || defined __LINUX__ || defined __APPLE__
+  #include <sys/time.h>
 #endif
 
 #define CELLMIN   (-1 << (8*sizeof(cell) - 1))

--- a/amx/fpattern.c
+++ b/amx/fpattern.c
@@ -99,7 +99,7 @@
 #define hexdigit(c)     ( ((c)>='0' && (c)<='9') ? (c) - '0' : 10 + \
                         ( ((c)>='a' && (c)<='f') ? (c) - 'a' : (c) - 'A' ) )
 #if !defined tolower
-# define tolower(c)     ( (c)>='A' && (c)<='Z' ? (c) - 'A' + 'a' : (c) )
+  #include <ctype.h>
 #endif
 
 #define BITSET(set,idx) ( (set)[(idx)/8] |= (unsigned char)(1 << ((idx) & 7)) )

--- a/amx/minIni.c
+++ b/amx/minIni.c
@@ -79,6 +79,7 @@
   #endif
 #endif
 #if !defined _totupper
+  #include <ctype.h>
   #define _totupper toupper
 #endif
 

--- a/amx/pawndbg.c
+++ b/amx/pawndbg.c
@@ -140,6 +140,8 @@ extern int chdir(const char *path); /* position of this function in header files
   #define amx_setattr(c,b,h) (_False)
   #define amx_termctl(c,v)  (_False)
   #define amx_console(c,l,f) (void)(0)
+  int getnstr(char *str, int n);
+  int printw(const char *fmt, ...);
   #define STR_PROMPT        "dbg> "
   #define CHR_HLINE         '-'
   #define CHR_VLINE         '|'
@@ -851,7 +853,7 @@ static int send_rs232(const char *buffer, int len)
     FlushFileBuffers(hCom);
   #else
     size=write(fdCom,buffer,len);
-    fflush(fileno(fcCom));
+    fflush((FILE*)(intptr_t)fileno((FILE*)&fdCom));
   #endif
   assert((unsigned long)len==size);
   return size;

--- a/compiler/sc1.c
+++ b/compiler/sc1.c
@@ -68,6 +68,7 @@
 #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
   #include <sclinux.h>
   #include <binreloc.h> /* from BinReloc, see www.autopackage.org */
+  #include <unistd.h>
 #endif
 
 #include "svnrev.h"


### PR DESCRIPTION
I have some errors and warnings when I compile pawn. And I tried to fix that. I know that it may contain some bugs because I'm not a C programmer, but it's better than nothing.

# CMake log

```
┌─ ziggi ~/devgit/pawn/build 
└─ $ cmake ..
-- The C compiler identification is GNU 6.1.1
-- The CXX compiler identification is GNU 6.1.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for inttypes.h
-- Looking for inttypes.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for alloca.h
-- Looking for alloca.h - found
-- Looking for curses.h
-- Looking for curses.h - found
-- Found DYNCALL: /usr/lib64/libdyncall_s.a;/usr/lib64/libdynload_s.a  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ziggi/devgit/pawn/build
```

# Make log
```
┌─ ziggi ~/devgit/pawn/build 
└─ $ make
Scanning dependencies of target pawndisasm
[  1%] Building C object compiler/CMakeFiles/pawndisasm.dir/pawndisasm.c.o
[  3%] Linking C executable ../pawndisasm
[  3%] Built target pawndisasm
Scanning dependencies of target pawncc
[  4%] Building C object compiler/CMakeFiles/pawncc.dir/sc1.c.o
/home/ziggi/devgit/pawn/compiler/sc1.c: In function ‘setopt’:
/home/ziggi/devgit/pawn/compiler/sc1.c:1425:11: warning: implicit declaration of function ‘access’ [-Wimplicit-function-declaration]
       if (access(cfgfile,4)==0)
           ^~~~~~
[  6%] Building C object compiler/CMakeFiles/pawncc.dir/sc2.c.o
[  8%] Building C object compiler/CMakeFiles/pawncc.dir/sc3.c.o
[  9%] Building C object compiler/CMakeFiles/pawncc.dir/sc4.c.o
[ 11%] Building C object compiler/CMakeFiles/pawncc.dir/sc5.c.o
[ 13%] Building C object compiler/CMakeFiles/pawncc.dir/sc6.c.o
[ 14%] Building C object compiler/CMakeFiles/pawncc.dir/sc7.c.o
[ 16%] Building C object compiler/CMakeFiles/pawncc.dir/scexpand.c.o
[ 18%] Building C object compiler/CMakeFiles/pawncc.dir/sci18n.c.o
[ 19%] Building C object compiler/CMakeFiles/pawncc.dir/sclist.c.o
[ 21%] Building C object compiler/CMakeFiles/pawncc.dir/scmemfil.c.o
[ 22%] Building C object compiler/CMakeFiles/pawncc.dir/scstate.c.o
[ 24%] Building C object compiler/CMakeFiles/pawncc.dir/scvars.c.o
[ 26%] Building C object compiler/CMakeFiles/pawncc.dir/lstring.c.o
[ 27%] Building C object compiler/CMakeFiles/pawncc.dir/memfile.c.o
[ 29%] Building C object compiler/CMakeFiles/pawncc.dir/__/amx/keeloq.c.o
[ 31%] Building C object compiler/CMakeFiles/pawncc.dir/__/linux/binreloc.c.o
[ 32%] Linking C executable ../pawncc
CMakeFiles/pawncc.dir/sc1.c.o: In function `pc_compile':
sc1.c:(.text+0x87f): warning: the use of `tempnam' is dangerous, better use `mkstemp'
[ 32%] Built target pawncc
Scanning dependencies of target amxFixed
[ 34%] Building C object amx/CMakeFiles/amxFixed.dir/amxfixed.c.o
[ 36%] Building C object amx/CMakeFiles/amxFixed.dir/amx.c.o
[ 37%] Linking C shared library ../amxFixed.so
[ 37%] Built target amxFixed
Scanning dependencies of target amxFile
[ 39%] Building C object amx/CMakeFiles/amxFile.dir/amxfile.c.o
In file included from /home/ziggi/devgit/pawn/amx/amxfile.c:128:0:
/home/ziggi/devgit/pawn/amx/minIni.c: In function ‘ini_getl’:
/home/ziggi/devgit/pawn/amx/minIni.c:82:21: warning: implicit declaration of function ‘toupper’ [-Wimplicit-function-declaration]
   #define _totupper toupper
                     ^
/home/ziggi/devgit/pawn/amx/minIni.c:341:37: note: in expansion of macro ‘_totupper’
                     : ((len >= 2 && _totupper((int)LocalBuffer[1]) == 'X') ? _tcstol(LocalBuffer, NULL, 16)
                                     ^~~~~~~~~
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fopen’:
/home/ziggi/devgit/pawn/amx/amxfile.c:508:10: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   return (cell)f;
          ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fclose’:
/home/ziggi/devgit/pawn/amx/amxfile.c:515:17: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   return fclose((FILE*)params[1]) == 0;
                 ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fwrite’:
/home/ziggi/devgit/pawn/amx/amxfile.c:536:19: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
       r=fputs(str,(FILE*)params[1]);
                   ^
/home/ziggi/devgit/pawn/amx/amxfile.c:540:18: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     r=fputs_cell((FILE*)params[1],cptr,1);
                  ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fread’:
/home/ziggi/devgit/pawn/amx/amxfile.c:568:22: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     chars=fgets_char((FILE*)params[1],str,max);
                      ^
/home/ziggi/devgit/pawn/amx/amxfile.c:573:22: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     chars=fgets_cell((FILE*)params[1],cptr,max,1);
                      ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fputchar’:
/home/ziggi/devgit/pawn/amx/amxfile.c:590:23: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     result=fputs_cell((FILE*)params[1],str,1);
                       ^
/home/ziggi/devgit/pawn/amx/amxfile.c:592:26: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     fputc((int)params[2],(FILE*)params[1]);
                          ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fgetchar’:
/home/ziggi/devgit/pawn/amx/amxfile.c:607:23: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     result=fgets_cell((FILE*)params[1],str,2,1);
                       ^
/home/ziggi/devgit/pawn/amx/amxfile.c:609:18: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     str[0]=fgetc((FILE*)params[1]);
                  ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fblockwrite’:
/home/ziggi/devgit/pawn/amx/amxfile.c:642:47: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
       if (fwrite(aligncell(&v),sizeof(cell),1,(FILE*)params[1])!=1)
                                               ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fblockread’:
/home/ziggi/devgit/pawn/amx/amxfile.c:661:35: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
       if (fread(&v,sizeof(cell),1,(FILE*)params[1])!=1)
                                   ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_ftemp’:
/home/ziggi/devgit/pawn/amx/amxfile.c:674:10: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   return (cell)tmpfile();
          ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fseek’:
/home/ziggi/devgit/pawn/amx/amxfile.c:697:10: warning: implicit declaration of function ‘lseek’ [-Wimplicit-function-declaration]
   return lseek(fileno((FILE*)params[1]),params[2],whence);
          ^~~~~
/home/ziggi/devgit/pawn/amx/amxfile.c:697:23: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   return lseek(fileno((FILE*)params[1]),params[2],whence);
                       ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fremove’:
/home/ziggi/devgit/pawn/amx/amxfile.c:101:25: warning: implicit declaration of function ‘_stat’ [-Wimplicit-function-declaration]
     #define _tstat      _stat
                         ^
/home/ziggi/devgit/pawn/amx/amxfile.c:715:7: note: in expansion of macro ‘_tstat’
       _tstat(fullname, &stbuf);
       ^~~~~~
/home/ziggi/devgit/pawn/amx/amxfile.c:100:25: warning: implicit declaration of function ‘_rmdir’ [-Wimplicit-function-declaration]
     #define _trmdir     _rmdir
                         ^
/home/ziggi/devgit/pawn/amx/amxfile.c:718:9: note: in expansion of macro ‘_trmdir’
       r=_trmdir(fullname);
         ^~~~~~~
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_flength’:
/home/ziggi/devgit/pawn/amx/amxfile.c:768:17: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   int fn=fileno((FILE*)params[1]);
                 ^
/home/ziggi/devgit/pawn/amx/amxfile.c: In function ‘n_fcreatedir’:
/home/ziggi/devgit/pawn/amx/amxfile.c:99:25: warning: implicit declaration of function ‘_mkdir’ [-Wimplicit-function-declaration]
     #define _tmkdir     _mkdir
                         ^
/home/ziggi/devgit/pawn/amx/amxfile.c:946:9: note: in expansion of macro ‘_tmkdir’
       r=_tmkdir(fullname,0755);
         ^~~~~~~
[ 40%] Building C object amx/CMakeFiles/amxFile.dir/amx.c.o
[ 42%] Linking C shared library ../amxFile.so
[ 42%] Built target amxFile
Scanning dependencies of target amxTime
[ 44%] Building C object amx/CMakeFiles/amxTime.dir/amxtime.c.o
/home/ziggi/devgit/pawn/amx/amxtime.c: In function ‘gettimestamp’:
/home/ziggi/devgit/pawn/amx/amxtime.c:71:5: warning: implicit declaration of function ‘gettimeofday’ [-Wimplicit-function-declaration]
     gettimeofday(&tv, NULL);
     ^~~~~~~~~~~~
[ 45%] Building C object amx/CMakeFiles/amxTime.dir/amx.c.o
[ 47%] Linking C shared library ../amxTime.so
[ 47%] Built target amxTime
Scanning dependencies of target amxDGram
[ 49%] Building C object amx/CMakeFiles/amxDGram.dir/amxdgram.c.o
[ 50%] Building C object amx/CMakeFiles/amxDGram.dir/amx.c.o
[ 52%] Linking C shared library ../amxDGram.so
[ 52%] Built target amxDGram
Scanning dependencies of target amxArgs
[ 54%] Building C object amx/CMakeFiles/amxArgs.dir/amxargs.c.o
/home/ziggi/devgit/pawn/amx/amxargs.c: In function ‘rawcmdline’:
/home/ziggi/devgit/pawn/amx/amxargs.c:120:46: warning: implicit declaration of function ‘getpid’ [-Wimplicit-function-declaration]
       sprintf(cmdbuffer, "/proc/%d/cmdline", getpid());
                                              ^~~~~~
[ 55%] Building C object amx/CMakeFiles/amxArgs.dir/amx.c.o
[ 57%] Linking C shared library ../amxArgs.so
[ 57%] Built target amxArgs
Scanning dependencies of target amxString
[ 59%] Building C object amx/CMakeFiles/amxString.dir/amxstring.c.o
[ 60%] Building C object amx/CMakeFiles/amxString.dir/amx.c.o
[ 62%] Building C object amx/CMakeFiles/amxString.dir/amxcons.c.o
[ 63%] Linking C shared library ../amxString.so
[ 63%] Built target amxString
Scanning dependencies of target amxProcess
[ 65%] Building C object amx/CMakeFiles/amxProcess.dir/amxprocess.c.o
/home/ziggi/devgit/pawn/amx/amxprocess.c: In function ‘n_libcall’:
/home/ziggi/devgit/pawn/amx/amxprocess.c:535:12: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
     result=(cell)dcCallPointer(dcVM,(void*)LibFunc);
            ^
[ 67%] Building C object amx/CMakeFiles/amxProcess.dir/amx.c.o
[ 68%] Linking C shared library ../amxProcess.so
[ 68%] Built target amxProcess
Scanning dependencies of target pawnrun
[ 70%] Building C object amx/CMakeFiles/pawnrun.dir/pawnrun.c.o
[ 72%] Building C object amx/CMakeFiles/pawnrun.dir/amx.c.o
[ 73%] Building C object amx/CMakeFiles/pawnrun.dir/amxcore.c.o
[ 75%] Building C object amx/CMakeFiles/pawnrun.dir/amxcons.c.o
[ 77%] Building C object amx/CMakeFiles/pawnrun.dir/amxpool.c.o
[ 78%] Building C object amx/CMakeFiles/pawnrun.dir/amxdbg.c.o
[ 80%] Building C object amx/CMakeFiles/pawnrun.dir/__/linux/binreloc.c.o
[ 81%] Linking C executable ../pawnrun
[ 81%] Built target pawnrun
Scanning dependencies of target amxFloat
[ 83%] Building C object amx/CMakeFiles/amxFloat.dir/amxfloat.c.o
[ 85%] Building C object amx/CMakeFiles/amxFloat.dir/amx.c.o
[ 86%] Linking C shared library ../amxFloat.so
[ 86%] Built target amxFloat
Scanning dependencies of target pawndbg
[ 88%] Building C object amx/CMakeFiles/pawndbg.dir/pawndbg.c.o
/home/ziggi/devgit/pawn/amx/pawndbg.c: In function ‘draw_hline’:
/home/ziggi/devgit/pawn/amx/pawndbg.c:131:29: warning: implicit declaration of function ‘printw’ [-Wimplicit-function-declaration]
   #define amx_printf        printw
                             ^
/home/ziggi/devgit/pawn/amx/pawndbg.c:349:3: note: in expansion of macro ‘amx_printf’
   amx_printf("%s",hline_str);
   ^~~~~~~~~~
/home/ziggi/devgit/pawn/amx/pawndbg.c: In function ‘send_rs232’:
/home/ziggi/devgit/pawn/amx/pawndbg.c:854:19: error: ‘fcCom’ undeclared (first use in this function)
     fflush(fileno(fcCom));
                   ^~~~~
/home/ziggi/devgit/pawn/amx/pawndbg.c:854:19: note: each undeclared identifier is reported only once for each function it appears in
/home/ziggi/devgit/pawn/amx/pawndbg.c: In function ‘rl_gets’:
/home/ziggi/devgit/pawn/amx/pawndbg.c:135:29: warning: implicit declaration of function ‘getnstr’ [-Wimplicit-function-declaration]
   #define amx_gets(s,n)     getnstr(s,n)
                             ^
/home/ziggi/devgit/pawn/amx/pawndbg.c:2095:5: note: in expansion of macro ‘amx_gets’
     amx_gets(str,length);
     ^~~~~~~~
make[2]: *** [amx/CMakeFiles/pawndbg.dir/build.make:63: amx/CMakeFiles/pawndbg.dir/pawndbg.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:531: amx/CMakeFiles/pawndbg.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

# Compiler log after changes
```
┌─ ziggi ~/devgit/pawn/build 
└─ $ make clean
┌─ ziggi ~/devgit/pawn/build 
└─ $ make
[  1%] Building C object compiler/CMakeFiles/pawndisasm.dir/pawndisasm.c.o
[  3%] Linking C executable ../pawndisasm
[  3%] Built target pawndisasm
[  4%] Building C object compiler/CMakeFiles/pawncc.dir/sc1.c.o
[  6%] Building C object compiler/CMakeFiles/pawncc.dir/sc2.c.o
[  8%] Building C object compiler/CMakeFiles/pawncc.dir/sc3.c.o
[  9%] Building C object compiler/CMakeFiles/pawncc.dir/sc4.c.o
[ 11%] Building C object compiler/CMakeFiles/pawncc.dir/sc5.c.o
[ 13%] Building C object compiler/CMakeFiles/pawncc.dir/sc6.c.o
[ 14%] Building C object compiler/CMakeFiles/pawncc.dir/sc7.c.o
[ 16%] Building C object compiler/CMakeFiles/pawncc.dir/scexpand.c.o
[ 18%] Building C object compiler/CMakeFiles/pawncc.dir/sci18n.c.o
[ 19%] Building C object compiler/CMakeFiles/pawncc.dir/sclist.c.o
[ 21%] Building C object compiler/CMakeFiles/pawncc.dir/scmemfil.c.o
[ 22%] Building C object compiler/CMakeFiles/pawncc.dir/scstate.c.o
[ 24%] Building C object compiler/CMakeFiles/pawncc.dir/scvars.c.o
[ 26%] Building C object compiler/CMakeFiles/pawncc.dir/lstring.c.o
[ 27%] Building C object compiler/CMakeFiles/pawncc.dir/memfile.c.o
[ 29%] Building C object compiler/CMakeFiles/pawncc.dir/__/amx/keeloq.c.o
[ 31%] Building C object compiler/CMakeFiles/pawncc.dir/__/linux/binreloc.c.o
[ 32%] Linking C executable ../pawncc
CMakeFiles/pawncc.dir/sc1.c.o: In function `pc_compile':
sc1.c:(.text+0x87f): warning: the use of `tempnam' is dangerous, better use `mkstemp'
[ 32%] Built target pawncc
[ 34%] Building C object amx/CMakeFiles/amxFixed.dir/amxfixed.c.o
[ 36%] Building C object amx/CMakeFiles/amxFixed.dir/amx.c.o
[ 37%] Linking C shared library ../amxFixed.so
[ 37%] Built target amxFixed
[ 39%] Building C object amx/CMakeFiles/amxFile.dir/amxfile.c.o
[ 40%] Building C object amx/CMakeFiles/amxFile.dir/amx.c.o
[ 42%] Linking C shared library ../amxFile.so
[ 42%] Built target amxFile
[ 44%] Building C object amx/CMakeFiles/amxTime.dir/amxtime.c.o
[ 45%] Building C object amx/CMakeFiles/amxTime.dir/amx.c.o
[ 47%] Linking C shared library ../amxTime.so
[ 47%] Built target amxTime
[ 49%] Building C object amx/CMakeFiles/amxDGram.dir/amxdgram.c.o
[ 50%] Building C object amx/CMakeFiles/amxDGram.dir/amx.c.o
[ 52%] Linking C shared library ../amxDGram.so
[ 52%] Built target amxDGram
[ 54%] Building C object amx/CMakeFiles/amxArgs.dir/amxargs.c.o
[ 55%] Building C object amx/CMakeFiles/amxArgs.dir/amx.c.o
[ 57%] Linking C shared library ../amxArgs.so
[ 57%] Built target amxArgs
[ 59%] Building C object amx/CMakeFiles/amxString.dir/amxstring.c.o
[ 60%] Building C object amx/CMakeFiles/amxString.dir/amx.c.o
[ 62%] Building C object amx/CMakeFiles/amxString.dir/amxcons.c.o
[ 63%] Linking C shared library ../amxString.so
[ 63%] Built target amxString
[ 65%] Building C object amx/CMakeFiles/amxProcess.dir/amxprocess.c.o
[ 67%] Building C object amx/CMakeFiles/amxProcess.dir/amx.c.o
[ 68%] Linking C shared library ../amxProcess.so
[ 68%] Built target amxProcess
[ 70%] Building C object amx/CMakeFiles/pawnrun.dir/pawnrun.c.o
[ 72%] Building C object amx/CMakeFiles/pawnrun.dir/amx.c.o
[ 73%] Building C object amx/CMakeFiles/pawnrun.dir/amxcore.c.o
[ 75%] Building C object amx/CMakeFiles/pawnrun.dir/amxcons.c.o
[ 77%] Building C object amx/CMakeFiles/pawnrun.dir/amxpool.c.o
[ 78%] Building C object amx/CMakeFiles/pawnrun.dir/amxdbg.c.o
[ 80%] Building C object amx/CMakeFiles/pawnrun.dir/__/linux/binreloc.c.o
[ 81%] Linking C executable ../pawnrun
[ 81%] Built target pawnrun
[ 83%] Building C object amx/CMakeFiles/amxFloat.dir/amxfloat.c.o
[ 85%] Building C object amx/CMakeFiles/amxFloat.dir/amx.c.o
[ 86%] Linking C shared library ../amxFloat.so
[ 86%] Built target amxFloat
[ 88%] Building C object amx/CMakeFiles/pawndbg.dir/pawndbg.c.o
[ 90%] Building C object amx/CMakeFiles/pawndbg.dir/amx.c.o
[ 91%] Building C object amx/CMakeFiles/pawndbg.dir/amxcore.c.o
[ 93%] Building C object amx/CMakeFiles/pawndbg.dir/amxcons.c.o
[ 95%] Building C object amx/CMakeFiles/pawndbg.dir/amxpool.c.o
[ 96%] Building C object amx/CMakeFiles/pawndbg.dir/amxdbg.c.o
[ 98%] Building C object amx/CMakeFiles/pawndbg.dir/__/linux/binreloc.c.o
[100%] Linking C executable ../pawndbg
[100%] Built target pawndbg
```

We still have:
```CMakeFiles/pawncc.dir/sc1.c.o: In function `pc_compile':
sc1.c:(.text+0x87f): warning: the use of `tempnam' is dangerous, better use `mkstemp'```
but I don't know how to fix this properly.