### PR TITLE
partially fix issue #26

### DIFF
--- a/amx/amx.c
+++ b/amx/amx.c
@@ -1000,6 +1000,10 @@ static int VerifyPcode(AMX *amx)
         amx->flags &= ~AMX_FLAG_VERIFY;
         return AMX_ERR_BOUNDS;
       } /* if */
+      if ((tgt&(sizeof(cell)-1))!=0) {
+        amx->flags &= ~AMX_FLAG_VERIFY;
+        return AMX_ERR_MEMACCESS;
+      } /* if */
       /* drop through */
     case OP_CALL_OVL:
       cip+=sizeof(cell);
@@ -2413,9 +2417,9 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
         CHKSTACK();
         break;
       case 5:
-        frm=pri;
-        if (frm<hea+STKMARGIN || (ucell)frm>=(ucell)amx->stp)
+        if (pri<hea+STKMARGIN || (ucell)pri>=(ucell)amx->stp)
           ABORT(amx,AMX_ERR_STACKERR);
+        frm=pri;
         break;
       case 6:
         /* verify address */
@@ -2835,7 +2839,7 @@ int AMXAPI amx_Exec(AMX *amx, cell *retval, int index)
       /* verify the index */
       stk+=_R(data,stk)+sizeof(cell);   /* remove parameters from the stack */
       i=amx->overlay(amx,amx->ovl_index); /* reload overlay */
-      if (i!=AMX_ERR_NONE || (long)offs>=amx->codesize)
+      if (i!=AMX_ERR_NONE || (long)offs>=amx->codesize || (offs&(sizeof(cell)-1))!=0)
         ABORT(amx,AMX_ERR_MEMACCESS);
       cip=(cell *)(amx->code+(int)offs);
       break;

--- a/amx/amxexec_gcc.c
+++ b/amx/amxexec_gcc.c
@@ -228,11 +228,17 @@ static const void * const amx_opcodelist[] = {
   op_lref_s_pri:
     GETPARAM(offs);
     offs=_R(data,frm+offs);
+    /* verify address */
+    if (offs>=hea && offs<stk || (ucell)offs>=(ucell)amx->stp)
+      ABORT(amx,AMX_ERR_MEMACCESS);
     pri=_R(data,offs);
     NEXT(cip,op);
   op_lref_s_alt:
     GETPARAM(offs);
     offs=_R(data,frm+offs);
+    /* verify address */
+    if (offs>=hea && offs<stk || (ucell)offs>=(ucell)amx->stp)
+      ABORT(amx,AMX_ERR_MEMACCESS);
     alt=_R(data,offs);
     NEXT(cip,op);
   op_load_i:
@@ -284,6 +290,9 @@ static const void * const amx_opcodelist[] = {
   op_sref_s:
     GETPARAM(offs);
     offs=_R(data,frm+offs);
+    /* verify address */
+    if (offs>=hea && offs<stk || (ucell)offs>=(ucell)amx->stp)
+      ABORT(amx,AMX_ERR_MEMACCESS);
     _W(data,offs,pri);
     NEXT(cip,op);
   op_stor_i:
@@ -353,14 +362,25 @@ static const void * const amx_opcodelist[] = {
       break;
     case 2:
       hea=pri;
+      CHKMARGIN();
+      CHKHEAP();
       break;
     case 4:
       stk=pri;
+      CHKMARGIN();
+      CHKSTACK();
       break;
     case 5:
       frm=pri;
+      if (frm<hea+STKMARGIN || (ucell)frm>=(ucell)amx->stp)
+        ABORT(amx,AMX_ERR_STACKERR);
       break;
     case 6:
+      /* verify address */
+      if (pri<0 || (long)pri>=amx->codesize)
+        ABORT(amx,AMX_ERR_BOUNDS);
+      if ((pri&(sizeof(cell)-1))!=0)
+        ABORT(amx,AMX_ERR_MEMACCESS);
       cip=(cell *)(amx->code + (int)pri);
       break;
     } /* switch */
@@ -412,7 +432,7 @@ static const void * const amx_opcodelist[] = {
     POP(frm);
     POP(offs);
     /* verify the return address */
-    if ((long)offs>=amx->codesize)
+    if (offs<0 || (long)offs>=amx->codesize || (offs&(sizeof(cell)-1))!=0)
       ABORT(amx,AMX_ERR_MEMACCESS);
     cip=(cell *)(amx->code+(int)offs);
     NEXT(cip,op);
@@ -420,7 +440,7 @@ static const void * const amx_opcodelist[] = {
     POP(frm);
     POP(offs);
     /* verify the return address */
-    if ((long)offs>=amx->codesize)
+    if (offs<0 || (long)offs>=amx->codesize || (offs&(sizeof(cell)-1))!=0)
       ABORT(amx,AMX_ERR_MEMACCESS);
     cip=(cell *)(amx->code+(int)offs);
     stk+= _R(data,stk) + sizeof(cell);  /* remove parameters from the stack */
@@ -1101,11 +1121,17 @@ static const void * const amx_opcodelist[] = {
   op_lref_p_s_pri:
     GETPARAM_P(offs,op);
     offs=_R(data,frm+offs);
+    /* verify address */
+    if (offs>=hea && offs<stk || (ucell)offs>=(ucell)amx->stp)
+      ABORT(amx,AMX_ERR_MEMACCESS);
     pri=_R(data,offs);
     NEXT(cip,op);
   op_lref_p_s_alt:
     GETPARAM_P(offs,op);
     offs=_R(data,frm+offs);
+    /* verify address */
+    if (offs>=hea && offs<stk || (ucell)offs>=(ucell)amx->stp)
+      ABORT(amx,AMX_ERR_MEMACCESS);
     alt=_R(data,offs);
     NEXT(cip,op);
   op_lodb_p_i:
@@ -1136,6 +1162,9 @@ static const void * const amx_opcodelist[] = {
   op_sref_p_s:
     GETPARAM_P(offs,op);
     offs=_R(data,frm+offs);
+    /* verify address */
+    if (offs>=hea && offs<stk || (ucell)offs>=(ucell)amx->stp)
+      ABORT(amx,AMX_ERR_MEMACCESS);
     _W(data,offs,pri);
     NEXT(cip,op);
   op_strb_p_i:

--- a/amx/amxexec_gcc.c
+++ b/amx/amxexec_gcc.c
@@ -371,9 +371,9 @@ static const void * const amx_opcodelist[] = {
       CHKSTACK();
       break;
     case 5:
-      frm=pri;
-      if (frm<hea+STKMARGIN || (ucell)frm>=(ucell)amx->stp)
+      if (pri<hea+STKMARGIN || (ucell)pri>=(ucell)amx->stp)
         ABORT(amx,AMX_ERR_STACKERR);
+      frm=pri;
       break;
     case 6:
       /* verify address */
@@ -799,7 +799,7 @@ static const void * const amx_opcodelist[] = {
     /* verify the index */
     stk+=_R(data,stk)+sizeof(cell);   /* remove parameters from the stack */
     num=amx->overlay(amx,amx->ovl_index); /* reload overlay */
-    if (num!=AMX_ERR_NONE || (long)offs>=amx->codesize)
+    if (num!=AMX_ERR_NONE || (long)offs>=amx->codesize || (offs&(sizeof(cell)-1))!=0)
       ABORT(amx,AMX_ERR_MEMACCESS);
     cip=(cell *)(amx->code+(int)offs);
     NEXT(cip,op);


### PR DESCRIPTION
Added checks to CASETBL and all of the jump opcodes in VerifyPcode and also to LREF.S.pri, LREF.S.alt, SREF.S, LREF.P.S.pri, LREF.P.S.alt, SREF.P.S, SCTRL, RET and RETN in amx_Exec.
I'm not 100% sure if the fix is correct, but I hope it will help.
Also these checks still need to be applied in the assembly cores, hence this fix is only partial.
