### PR TITLE
Fix negative numbers output

### DIFF
--- a/amx/amxcons.c
+++ b/amx/amxcons.c
@@ -610,19 +610,12 @@ static TCHAR *amx_strval(TCHAR buffer[], long value, int format, int width)
 		if (value < 0) {
 			buffer[0] = __T('-');
 			start = stop = 1;
-      do {
-        temp = (TCHAR)(value % 10);
-        if (temp > 0)
-          temp = (TCHAR)(temp - 10);
-        buffer[stop++] = (TCHAR)(__T('0') - temp);
-        value /= 10;
-      } while (value != 0);
-		} else {
-      do {
-        buffer[stop++] = (TCHAR)((value % 10) + __T('0'));
-        value /= 10;
-      } while (value != 0);
-    }
+			value = -value;
+		}
+		do {
+			buffer[stop++] = (TCHAR)((value % 10) + __T('0'));
+			value /= 10;
+		} while (value != 0);
 	} else {
 		/* hexadecimal */
 		unsigned long v = (unsigned long)value;	/* copy to unsigned value for shifting */


### PR DESCRIPTION
Correction of output of negative numbers. IAR EW ARM Compiler
Before the fix:
printf("RSSI=%d", -96)
Output: "RSSI=-C@"
After the fix:
printf("RSSI=%d", -96)
Output: "RSSI=-96"