### PR TITLE
Fixes for build on Windows

### DIFF
--- a/amx/amx.c
+++ b/amx/amx.c
@@ -1497,7 +1497,7 @@ int AMXAPI amx_Cleanup(AMX *amx)
           if (libcleanup!=NULL)
             libcleanup(amx);
           #if defined _Windows
-            FreeLibrary(hlob);
+            FreeLibrary(hlib);
           #elif defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
             dlclose(hlib);
           #endif

--- a/compiler/pawncc.rc
+++ b/compiler/pawncc.rc
@@ -6,7 +6,7 @@
 #endif
 #include "svnrev.h"
 
-AppIcon ICON "../bin/pawn.ico"
+AppIcon ICON "../pawn.ico"
 
 /*  Version information
  *


### PR DESCRIPTION
The errors occurred in code that would only be compiled for Windows. It now builds successfully.