### PR TITLE
Remove Unused int i and fix type in amx.c

### DIFF
--- a/amx/amx.c
+++ b/amx/amx.c
@@ -1102,7 +1102,6 @@ static int VerifyPcode(AMX *amx)
 
   static void getlibname(char *libname,const char *source)
   {
-    int i;
     #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
       char *root=getenv("AMXLIB");
     #endif

--- a/amx/amx.c
+++ b/amx/amx.c
@@ -1496,7 +1496,7 @@ int AMXAPI amx_Cleanup(AMX *amx)
           if (libcleanup!=NULL)
             libcleanup(amx);
           #if defined _Windows
-            FreeLibrary(hlob);
+            FreeLibrary(hlib);
           #elif defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
             dlclose(hlib);
           #endif


### PR DESCRIPTION
An unused integer "i" is declared in the function getlibname.

A typo exists in the function amx_Cleanup to free a "hlob".  It should free a "hlib"