### PR TITLE
waitpid requires <sys/wait.h> to be included

### DIFF
--- a/compiler/sc1.c
+++ b/compiler/sc1.c
@@ -74,6 +74,7 @@
 #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
   #include <sclinux.h>
   #include <binreloc.h> /* from BinReloc, see www.autopackage.org */
+  #include <sys/wait.h>
 #endif
 
 #include "svnrev.h"


### PR DESCRIPTION
I tried building the compiler using Alpine and Ubuntu linux. Both output the following warning:

```
/home/pawn/compiler/sc1.c: In function 'posix_spawnl':
/home/pawn/compiler/sc1.c:460:5: warning: implicit declaration of function 'waitpid' [-Wimplicit-function-declaration]
  460 |     waitpid(pid,&stat,0);
      |     ^~~~~~~
```

Including `<sys/wait.h>` resolved this issue.

Builds successfully using Alpine Linux after the change.

Closes #60 