### PR TITLE
Fix occasional segmentation fault for free_symbol

### DIFF
--- a/compiler/sc1.c
+++ b/compiler/sc1.c
@@ -3435,7 +3435,7 @@ SC_FUNC symbol *fetchfunc(const char *name,int tag)
     sym=addsym(name,code_idx,iFUNCTN,sGLOBAL,tag,0);
     assert(sym!=NULL);          /* fatal error 103 must be given on error */
     /* assume no arguments */
-    sym->dim.arglist=(arginfo*)malloc(1*sizeof(arginfo));
+    sym->dim.arglist=(arginfo*)calloc(1, sizeof(arginfo));
     sym->dim.arglist[0].ident=0;
     /* set library ID to NULL (only for native functions) */
     sym->x.lib=NULL;
@@ -4233,7 +4233,7 @@ static int declargs(symbol *sym,int chkshadow)
   int argcnt,oldargcnt,tok,numtags;
   int tags[MAXTAGS];
   cell val;
-  arginfo arg;
+  arginfo arg = { 0 };
   arginfo *arglist;
   char name[sNAMEMAX+1];
   int ident,fpublic,fconst;


### PR DESCRIPTION
When processing functions with variable arguments, the 'numdim' and 'dimnames' parameters of s_arginfo aren't set or cleared. Due to a malloc (w/ no memory clear), this can cause a segmentation fault when attempting to free the symbol.