### PR TITLE
Add the ".pwn" file extension

### DIFF
--- a/compiler/sc2.c
+++ b/compiler/sc2.c
@@ -121,7 +121,7 @@ SC_FUNC void clearstk(void)
 
 SC_FUNC int plungequalifiedfile(char *name)
 {
-static char *extensions[] = { ".i", ".inc", ".p", ".pawn" };
+static char *extensions[] = { ".i", ".inc", ".p", ".pawn", ".pwn" };
   FILE *fp;
   char *ext;
   int ext_idx;


### PR DESCRIPTION
Many scripters across the PAWN community use the `.pwn` file extension (including me) instead of `.p` (for some reason this reminds of Pascal) or `.pawn`.