### PR TITLE
RFC: pc_compile: Write the output binfile to the directory passed in argv[0]

### DIFF
--- a/compiler/sc1.c
+++ b/compiler/sc1.c
@@ -516,7 +516,7 @@ int pc_compile(int argc, char *argv[])
 
   setconfig(argv[0]);   /* the path to the include and codepage files, plus the root path */
   setopt(argc,argv,outfname,errfname,incfname,reportname,codepage);
-  strcpy(binfname,outfname);
+  sprintf(binfname, "%s/%s", argv[0], outfname);
   ptr=get_extension(binfname);
   if (ptr!=NULL && stricmp(ptr,".asm")==0)
     set_extension(binfname,".amx",TRUE);


### PR DESCRIPTION
I don't know about every use case, but our app expects the compiled pawn file in the same directory as the source.

Maybe a new option to pass the output directory instead of writing the output into the current working directory would be better?